### PR TITLE
Specify package includes in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbola/svgo-loader",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperbola/svgo-loader",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "evergreen svgo loader for webpack",
   "keywords": [
     "svgo",
@@ -16,6 +16,11 @@
   ],
   "repository": "github:lopopolo/svgo-loader",
   "main": "index.js",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "index.js"
+  ],
   "dependencies": {},
   "peerDependencies": {
     "svgo": "^1.0.0"


### PR DESCRIPTION
`npm publish` was packaging dotfiles, tests, and other files not
relevant to running `@hyperbola/svgo-loader`, which bloats package
install size.

Use the `files` property in `package.json` to only pack `LICENSE`,
`README.md`, `index.js`, and `package.json` when publishing. This change
has been validated with `npm pack`.